### PR TITLE
update module manifest for v11 structures and pf2e v5+ ownership

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
         contents: write
+        actions: write
+        
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+        contents: write
     steps:
     - uses: actions/checkout@v2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.6.0
+
+- Updated to Foundry version 11.306 and Pathfinder 2E System Version 5.2.3. These are the first supported versions on Foundry version 11.
+- Added a pack folder to consolidate the different compendiums.
+
 # 1.5.0
 - Added lighting to the Spire Dormitory map. Enjoy your night outs.
 - Fixed some feats Rule Elements predicates.

--- a/module.json
+++ b/module.json
@@ -5,13 +5,12 @@
 	"version": "This is replaced",
 	"authors": [
 		{
-			"name": "MrVauxs",
-			"flags": {}
+			"name": "MrVauxs"
 		}
 	],
 	"compatibility": {
-		"minimum": "10",
-		"verified": "10"
+		"minimum": "11",
+		"verified": "11.306"
 	},
 	"relationships": {
 		"systems": [
@@ -19,11 +18,23 @@
 				"id": "pf2e",
 				"type": "system",
 				"compatibility": {
-					"minimum": "4.4.2"
+					"minimum": "5.2.3"
 				}
 			}
 		]
 	},
+	"packFolders": [
+		{
+			"name": "PF2e Magaambya",
+			"sorting": "m",
+			"packs": [
+				"Maps",
+				"journals",
+				"Macros",
+				"Feats"
+			]
+		}
+	],
 	"packs": [
 		{
 			"label": "PF2e Magaambya Maps",
@@ -32,7 +43,10 @@
 			"system": "pf2e",
 			"type": "Adventure",
 			"private": true,
-			"flags": {}
+			"ownership": {
+				"PLAYER": "LIMITED",
+				"ASSISTANT": "OWNER"
+			}
 		},
 		{
 			"label": "PF2e Magaambya Journals",
@@ -40,8 +54,10 @@
 			"path": "packs/journal.db",
 			"system": "pf2e",
 			"type": "JournalEntry",
-			"private": false,
-			"flags": {}
+			"ownership": {
+				"PLAYER": "LIMITED",
+				"ASSISTANT": "OWNER"
+			}
 		},
 		{
 			"label": "PF2e Magaambya Macros",
@@ -49,8 +65,10 @@
 			"path": "packs/macros.db",
 			"system": "pf2e",
 			"type": "Macro",
-			"private": false,
-			"flags": {}
+			"ownership": {
+				"PLAYER": "LIMITED",
+				"ASSISTANT": "OWNER"
+			}
 		},
 		{
 			"label": "PF2e Magaambya Feats",
@@ -58,8 +76,10 @@
 			"path": "packs/feats.db",
 			"system": "pf2e",
 			"type": "Item",
-			"private": false,
-			"flags": {}
+			"ownership": {
+				"PLAYER": "OBSERVER",
+				"ASSISTANT": "OWNER"
+			}
 		}
 	],
 	"url": "https://github.com/MrVauxs/pf2e-magaambya",

--- a/module.json
+++ b/module.json
@@ -82,7 +82,7 @@
 			}
 		}
 	],
-	"url": "https://github.com/MrVauxs/pf2e-magaambya",
+	"url": "https://github.com/baronfel/pf2e-magaambya",
 	"manifest": "This is replaced",
 	"download": "This is replaced",
 	"readme": "https://github.com/MrVauxs/pf2e-magaambya",

--- a/module.json
+++ b/module.json
@@ -82,7 +82,8 @@
 			}
 		}
 	],
-	"url": "https://github.com/baronfel/pf2e-magaambya",
+	"url": "https://github.com/MrVauxs/pf2e-magaambya",
+
 	"manifest": "This is replaced",
 	"download": "This is replaced",
 	"readme": "https://github.com/MrVauxs/pf2e-magaambya",


### PR DESCRIPTION
Closes #1 

Hello! This PR should update this module to Foundry v11 stable (11.306) as well as the pf2e system version 5.2.3. Both of these are the minimums for their respective pairing (e.g. 5.2.3 is the first available PF2e system for foundry 11, and it requires 11.306). This should hopefully result in the broadest compatibility.

All of the _content_ of the module remains the same - I have done three things mostly:

* updated the `private` field to the new permissions structures, following along with [the docs]() at the PF2E system wiki
* put the compendiums contributed by this module into a folder for the module for easier location:
![image](https://github.com/MrVauxs/pf2e-magaambya/assets/573979/2502e511-f169-4986-8385-597bfed5beb6)
* updated the changelogs to describe the changes


With that done I was able to make a release on [my fork](https://github.com/baronfel/pf2e-magaambya/releases/tag/1.6.0) and then test the manifest + contents on my local Foundry instance. All seems well!

![image](https://github.com/MrVauxs/pf2e-magaambya/assets/573979/c25d429c-4718-44ab-9f4d-f49715f40021)

I was able to use the macro to award an actor with the two schools, and use the feats as I am in my 10.x foundry game.

The maps import and are usable: 
![image](https://github.com/MrVauxs/pf2e-magaambya/assets/573979/22917453-7bd7-4b93-b2b3-ccc681777ec1)

The character journals still import and seem to have the same content they do in 10.x:
![image](https://github.com/MrVauxs/pf2e-magaambya/assets/573979/005a24c8-b921-4a29-bca0-56ef09fb083d)

Please let me know what other things I should test
